### PR TITLE
suppress creation of default metrics

### DIFF
--- a/cmd/mq2prom.go
+++ b/cmd/mq2prom.go
@@ -29,7 +29,7 @@ func main() {
 
 	sm := manager.NewSimpleManager()
 
-	sm.Init(manager.MetricSpec{
+	registry := sm.Init(manager.MetricSpec{
 		Metrics: conf.Metrics,
 	})
 
@@ -62,7 +62,8 @@ func main() {
 	}
 	log.Info("Subscribed to topic: ", conf.MqConfig.Topic)
 
-	http.Handle("/metrics", promhttp.Handler())
+	handler := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
+	http.Handle("/metrics", handler)
 
 	log.Info("Starting up metric endpoint at :9641")
 	log.Fatal(http.ListenAndServe(mqIP+":9641", nil))

--- a/pkg/metric-manager/manager.go
+++ b/pkg/metric-manager/manager.go
@@ -8,7 +8,7 @@ import (
 
 type Manager interface {
 	// Initialize the Metric Manager with a list of metrics to track
-	Init(MetricSpec)
+	Init(MetricSpec) *prometheus.Registry
 	// Update a set of metrics in a single message payload
 	Update(MQPayload)
 }
@@ -26,7 +26,9 @@ func NewSimpleManager() *SimpleManager {
 	}
 }
 
-func (m *SimpleManager) Init(metricSpec MetricSpec) {
+func (m *SimpleManager) Init(metricSpec MetricSpec) *prometheus.Registry {
+	r := prometheus.NewRegistry()
+
 	for _, mc := range metricSpec.Metrics {
 		var metricCollector prometheus.Collector
 
@@ -44,12 +46,14 @@ func (m *SimpleManager) Init(metricSpec MetricSpec) {
 		}
 
 		// register this metric with Prometheus
-		prometheus.MustRegister(metricCollector)
+		r.MustRegister(metricCollector)
 
 		// store this metric collector for future use
 		m.metrics[mc.MQName] = metricCollector
 		m.metricTypes[mc.MQName] = mc.Type
 	}
+
+	return r
 }
 
 func (m *SimpleManager) Update(mqpayload MQPayload) {


### PR DESCRIPTION
only share metrics from the bus, no "meta" metrics like go_, process_ etc