### PR TITLE
docker: use multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
-FROM golang:1.20.10-alpine
-RUN mkdir /mq2prom
-COPY . /mq2prom
-WORKDIR /mq2prom
+# Builder phase, includes golang toolchain
+FROM golang:1.20.11-alpine3.18 as builder
+COPY . /src
+WORKDIR /src
 RUN go build -o mq2prom ./cmd
-CMD ./mq2prom
+
+# Runtime phase, contains bare alpine plus the built binary and the config file
+# IMPORTANT: keep the alpine version on the builder and the runtime base images aligned
+FROM alpine:3.18
+RUN mkdir /mq2prom
+WORKDIR /mq2prom
+COPY --from=builder /src/mq2prom /src/config.yaml .
+CMD ["./mq2prom"]


### PR DESCRIPTION
By leveraging docker's multi-stage builds, the size of the final mq2prom docker image is reduced from 409MB to 21.2MB.

This also adds extra hardening to the image, because a lot less packages and intermediate artifacts are included as part of it.

As part of this commit, the go version used to build the binary inside the docker image has been bumped to 1.20.11, and I changed the `CMD` statement so it uses the [exec](https://docs.docker.com/engine/reference/builder/#cmd) form instead of the shell one. This allows the `mq2prom` binary to own PID1 on the container, and receive signals from docker (e.g. `SIGTERM` for graceful termination) which were previously intercepted by the shell that was spawned to launch the process.

Fixes: #11